### PR TITLE
feat: Swagger에서 엑셀 업로드 API가 멀티파트 요청으로 보이도록 수정

### DIFF
--- a/src/main/java/com/sysmatic2/finalbe/strategy/controller/ExcelUploadController.java
+++ b/src/main/java/com/sysmatic2/finalbe/strategy/controller/ExcelUploadController.java
@@ -4,6 +4,9 @@ import com.sysmatic2.finalbe.strategy.dto.DailyStatisticsReqDto;
 import com.sysmatic2.finalbe.strategy.service.ExcelUploadService;
 import com.sysmatic2.finalbe.exception.ExcelValidationException;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.HttpStatus;
@@ -26,12 +29,18 @@ public class ExcelUploadController {
 
   @Operation(summary = "엑셀 파일 업로드 및 데이터 추출", description = "엑셀 파일을 업로드하고 데이터를 추출하여 반환합니다.")
   @ApiResponses(value = {
-          @ApiResponse(responseCode = "200", description = "엑셀 데이터 추출 성공"),
+          @ApiResponse(responseCode = "201", description = "엑셀 데이터 추출 성공"),
           @ApiResponse(responseCode = "400", description = "잘못된 엑셀 파일 형식"),
           @ApiResponse(responseCode = "500", description = "서버 오류")
   })
-  @PostMapping(value = "/upload", produces = "application/json") // 같은 엔드포인트 "/upload"
-  public ResponseEntity<Map<String, Object>> uploadExcelFile(@RequestParam("file") MultipartFile file) {
+  @PostMapping(value = "/upload", consumes = "multipart/form-data", produces = "application/json")
+  public ResponseEntity<Map<String, Object>> uploadExcelFile(
+          @RequestParam("file")
+          @RequestBody(content = @Content(
+                  mediaType = "multipart/form-data",
+                  schema = @Schema(type = "string", format = "binary")
+          ))
+          MultipartFile file) {
     try {
       // 엑셀 파일에서 데이터를 추출하고 검증
       List<DailyStatisticsReqDto> result = excelUploadService.extractAndValidateData(file);


### PR DESCRIPTION
**바로 머지하지 마세요! 검토 후 머지해야합니다!**

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
ex) 
엑셀 파일 업로드 API Swagger에서 멀티파트 요청으로 명확히 보이도록 수정
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
ex) 
ExcelUploadController 수정
Swagger에서 파일 업로드 요청을 명확히 표현하기 위해 consumes = "multipart/form-data" 추가
<br />

## :: 쓰이는 모듈
ex)


<br />

## :: 기타 질문 및 특이 사항
