### PR TITLE
feat(api): 엑셀 파일 업로드 기능 테스트 및 서비스 로직 개선

### DIFF
--- a/src/test/java/com/sysmatic2/finalbe/strategy/controller/ExcelUploadControllerTest.java
+++ b/src/test/java/com/sysmatic2/finalbe/strategy/controller/ExcelUploadControllerTest.java
@@ -1,8 +1,11 @@
 package com.sysmatic2.finalbe.strategy.controller;
 
-import com.sysmatic2.finalbe.strategy.dto.DailyStatisticsReqDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sysmatic2.finalbe.strategy.entity.DailyStatisticsEntity;
+import com.sysmatic2.finalbe.strategy.entity.StrategyEntity;
 import com.sysmatic2.finalbe.strategy.service.ExcelUploadService;
 import com.sysmatic2.finalbe.exception.ExcelValidationException;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,13 +16,13 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -30,40 +33,98 @@ public class ExcelUploadControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
-  @MockBean
+  @MockBean // ExcelUploadService를 Mock으로 주입
   private ExcelUploadService excelUploadService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
 
   private MockMultipartFile validFile;
   private MockMultipartFile invalidFile;
   private MockMultipartFile serverErrorFile;
+  private MockMultipartFile specificErrorFile;
 
   private Long validStrategyId = 1L;
   private Long invalidStrategyId = 999L;
 
   @BeforeEach
-  public void setup() {
+  public void setup() throws Exception {
     // 성공적인 업로드를 위한 유효한 엑셀 파일 준비
+    XSSFWorkbook workbook = new XSSFWorkbook();
+    var sheet = workbook.createSheet("Sheet1");
+    var header = sheet.createRow(0);
+    header.createCell(0).setCellValue("Date");
+    header.createCell(1).setCellValue("DepWdPrice");
+    header.createCell(2).setCellValue("DailyProfitLoss");
+
+    var row1 = sheet.createRow(1);
+    row1.createCell(0).setCellValue(LocalDate.of(2024, 1, 1).toString());
+    row1.createCell(1).setCellValue(1000.00); // 입금
+    row1.createCell(2).setCellValue(200.00); // 이익
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    workbook.write(bos);
+    workbook.close();
     validFile = new MockMultipartFile(
             "file",
-            "test.xlsx",
+            "valid.xlsx",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            "dummy content".getBytes()
+            bos.toByteArray()
     );
 
-    // 유효성 검사 실패를 위한 잘못된 엑셀 파일 준비
+    // 유효성 검사 실패를 위한 잘못된 엑셀 파일 준비 (여러 시트 포함)
+    XSSFWorkbook invalidWorkbook = new XSSFWorkbook();
+    invalidWorkbook.createSheet("Sheet1");
+    invalidWorkbook.createSheet("Sheet2"); // 두 번째 시트 추가 (유효성 검사 실패)
+    ByteArrayOutputStream invalidBos = new ByteArrayOutputStream();
+    invalidWorkbook.write(invalidBos);
+    invalidWorkbook.close();
     invalidFile = new MockMultipartFile(
             "file",
-            "invalid.xlsx",
+            "invalid_sheets.xlsx",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            "invalid content".getBytes()
+            invalidBos.toByteArray()
     );
 
     // 서버 오류를 시뮬레이션하기 위한 파일 준비 (내용은 동일하지만 서비스에서 예외 발생)
+    XSSFWorkbook serverErrorWorkbook = new XSSFWorkbook();
+    var serverSheet = serverErrorWorkbook.createSheet("Sheet1");
+    var serverHeader = serverSheet.createRow(0);
+    serverHeader.createCell(0).setCellValue("Date");
+    serverHeader.createCell(1).setCellValue("DepWdPrice");
+    serverHeader.createCell(2).setCellValue("DailyProfitLoss");
+
+    var serverRow1 = serverSheet.createRow(1);
+    serverRow1.createCell(0).setCellValue("2024-01-11");
+    serverRow1.createCell(1).setCellValue(300000000);
+    serverRow1.createCell(2).setCellValue(-4018350);
+
+    ByteArrayOutputStream serverBos = new ByteArrayOutputStream();
+    serverErrorWorkbook.write(serverBos);
+    serverErrorWorkbook.close();
     serverErrorFile = new MockMultipartFile(
             "file",
             "server_error.xlsx",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            "server error content".getBytes()
+            serverBos.toByteArray()
+    );
+
+    // 특정 예외 시나리오를 위한 파일 준비 (예: average_loss 컬럼 누락)
+    XSSFWorkbook specificErrorWorkbook = new XSSFWorkbook();
+    var specificSheet = specificErrorWorkbook.createSheet("Sheet1");
+    var specificHeader = specificSheet.createRow(0);
+    specificHeader.createCell(0).setCellValue("Date");
+    specificHeader.createCell(1).setCellValue("DepWdPrice");
+    // "DailyProfitLoss" 컬럼 누락하여 오류 유발
+
+    ByteArrayOutputStream specificBos = new ByteArrayOutputStream();
+    specificErrorWorkbook.write(specificBos);
+    specificErrorWorkbook.close();
+    specificErrorFile = new MockMultipartFile(
+            "file",
+            "specific_error.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            specificBos.toByteArray()
     );
   }
 
@@ -72,16 +133,20 @@ public class ExcelUploadControllerTest {
   @WithMockUser // 사용자 인증 정보 제공
   public void 엑셀파일업로드_성공적일경우_생성상태가반환되어야한다() throws Exception {
     // 서비스의 동작을 미리 정의 (예시)
-    List<DailyStatisticsReqDto> mockResult = List.of(
-            DailyStatisticsReqDto.builder()
-                    .date(LocalDate.of(2024, 1, 1))
-                    .depWdPrice(new BigDecimal("1000.00"))
-                    .dailyProfitLoss(new BigDecimal("200.00"))
-                    .build()
-    );
+    StrategyEntity strategyEntity = new StrategyEntity();
+    strategyEntity.setStrategyId(validStrategyId);
 
-    when(excelUploadService.extractAndSaveData(any(MockMultipartFile.class), anyLong()))
-            .thenReturn(mockResult);
+    DailyStatisticsEntity mockSavedEntity = DailyStatisticsEntity.builder()
+            .dailyStatisticsId(1L)
+            .strategyEntity(strategyEntity)
+            .date(LocalDate.of(2024, 1, 1))
+            .depWdPrice(new BigDecimal("1000.00"))
+            .dailyProfitLoss(new BigDecimal("200.00"))
+            // 필요한 다른 필드도 설정
+            .build();
+
+    when(excelUploadService.extractAndSaveData(any(MockMultipartFile.class), eq(validStrategyId)))
+            .thenReturn(List.of(mockSavedEntity));
 
     mockMvc.perform(multipart("/api/strategies/{strategyId}/upload", validStrategyId)
                     .file(validFile) // 유효한 엑셀 파일 업로드
@@ -94,15 +159,18 @@ public class ExcelUploadControllerTest {
             .andExpect(jsonPath("$.data[0].date").value("2024-01-01"))
             .andExpect(jsonPath("$.data[0].depWdPrice").value(1000.00))
             .andExpect(jsonPath("$.data[0].dailyProfitLoss").value(200.00));
+
+    // Service 메서드 호출 검증
+    verify(excelUploadService, times(1)).extractAndSaveData(any(MockMultipartFile.class), eq(validStrategyId));
   }
 
   // 잘못된 형식의 엑셀 파일이 업로드될 경우 400 Bad Request를 반환하는지 확인하는 테스트
   @Test
   @WithMockUser // 사용자 인증 정보 제공
   public void 엑셀파일업로드_유효성검사실패_잘못된형식의엑셀파일일경우_오류메시지가반환되어야한다() throws Exception {
-    // 서비스의 동작을 미리 정의 (유효성 검사 실패 시 예외 던지기)
-    when(excelUploadService.extractAndSaveData(any(MockMultipartFile.class), anyLong()))
-            .thenThrow(new ExcelValidationException("Invalid Excel file format"));
+    // 서비스의 동작을 미리 정의 (유효성 검사 실패 시 ExcelValidationException 던지기)
+    when(excelUploadService.extractAndSaveData(any(MockMultipartFile.class), eq(validStrategyId)))
+            .thenThrow(new ExcelValidationException("엑셀 파일에 여러 시트가 포함되어 있습니다. 첫 번째 시트만 허용됩니다."));
 
     mockMvc.perform(multipart("/api/strategies/{strategyId}/upload", validStrategyId)
                     .file(invalidFile) // 잘못된 형식의 엑셀 파일 업로드
@@ -111,16 +179,19 @@ public class ExcelUploadControllerTest {
             .andExpect(status().isBadRequest()) // 상태 400 Bad Request 예상
             .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.msg").value("EXCEL_VALIDATION_FAILED")) // 응답 메시지 확인
-            .andExpect(jsonPath("$.error").value("Invalid Excel file format")); // 오류 메시지 확인
+            .andExpect(jsonPath("$.error").value("엑셀 파일에 여러 시트가 포함되어 있습니다. 첫 번째 시트만 허용됩니다.")); // 오류 메시지 확인
+
+    // Service 메서드 호출 검증
+    verify(excelUploadService, times(1)).extractAndSaveData(any(MockMultipartFile.class), eq(validStrategyId));
   }
 
-  // 전략 ID가 유효하지 않은 경우 400 Bad Request를 반환하는지 확인하는 테스트
+  // 유효하지 않은 전략 ID로 엑셀 파일 업로드 시 400 Bad Request를 반환하는지 확인하는 테스트
   @Test
   @WithMockUser // 사용자 인증 정보 제공
   public void 엑셀파일업로드_유효하지않은전략ID일경우_오류메시지가반환되어야한다() throws Exception {
-    // 서비스의 동작을 미리 정의 (유효하지 않은 전략 ID 시 예외 던지기)
-    when(excelUploadService.extractAndSaveData(any(MockMultipartFile.class), anyLong()))
-            .thenThrow(new IllegalArgumentException("Invalid strategyId: " + invalidStrategyId));
+    // 서비스의 동작을 미리 정의 (유효하지 않은 전략 ID 시 IllegalArgumentException 던지기)
+    when(excelUploadService.extractAndSaveData(any(MockMultipartFile.class), eq(invalidStrategyId)))
+            .thenThrow(new IllegalArgumentException("유효하지 않은 전략 ID입니다: " + invalidStrategyId));
 
     mockMvc.perform(multipart("/api/strategies/{strategyId}/upload", invalidStrategyId)
                     .file(validFile) // 유효한 엑셀 파일 업로드
@@ -129,15 +200,18 @@ public class ExcelUploadControllerTest {
             .andExpect(status().isBadRequest()) // 상태 400 Bad Request 예상
             .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.msg").value("EXCEL_UPLOAD_FAILED")) // 응답 메시지 확인
-            .andExpect(jsonPath("$.error").value("Invalid strategyId: " + invalidStrategyId)); // 오류 메시지 확인
+            .andExpect(jsonPath("$.error").value("유효하지 않은 전략 ID입니다: " + invalidStrategyId)); // 오류 메시지 확인
+
+    // Service 메서드 호출 검증
+    verify(excelUploadService, times(1)).extractAndSaveData(any(MockMultipartFile.class), eq(invalidStrategyId));
   }
 
   // 서버 내부 오류가 발생할 경우 500 Internal Server Error를 반환하는지 확인하는 테스트
   @Test
   @WithMockUser // 사용자 인증 정보 제공
   public void 엑셀파일업로드_서버오류시_500반환() throws Exception {
-    // 서비스의 동작을 미리 정의 (서버 오류 시 예외 던지기)
-    when(excelUploadService.extractAndSaveData(any(MockMultipartFile.class), anyLong()))
+    // 서비스의 동작을 미리 정의 (서버 오류 시 RuntimeException 던지기)
+    when(excelUploadService.extractAndSaveData(any(MockMultipartFile.class), eq(validStrategyId)))
             .thenThrow(new RuntimeException("Unexpected error"));
 
     mockMvc.perform(multipart("/api/strategies/{strategyId}/upload", validStrategyId)
@@ -148,6 +222,49 @@ public class ExcelUploadControllerTest {
             .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.msg").value("EXCEL_UPLOAD_FAILED")) // 응답 메시지 확인
             .andExpect(jsonPath("$.error").value("Unexpected error")); // 오류 메시지 확인
+
+    // Service 메서드 호출 검증
+    verify(excelUploadService, times(1)).extractAndSaveData(any(MockMultipartFile.class), eq(validStrategyId));
+  }
+
+  // 특정 예외 시나리오 - 컬럼 누락으로 인한 오류 발생 시 400 Bad Request를 반환하는 테스트
+  @Test
+  @WithMockUser // 사용자 인증 정보 제공
+  public void 엑셀파일업로드_특정예외시_400반환() throws Exception {
+    // 서비스의 동작을 미리 정의 (특정 조건 시 ExcelValidationException 던지기)
+    when(excelUploadService.extractAndSaveData(any(MockMultipartFile.class), eq(1L)))
+            .thenThrow(new ExcelValidationException("Column 'average_loss' cannot be null"));
+
+    // 특정 예외 시나리오를 위한 파일 준비
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    var workbook = new XSSFWorkbook();
+    var sheet = workbook.createSheet("Sheet1");
+
+    var header = sheet.createRow(0);
+    header.createCell(0).setCellValue("Date");
+    header.createCell(1).setCellValue("DepWdPrice");
+    // "DailyProfitLoss" 컬럼 누락하여 특정 예외 유발
+
+    workbook.write(out);
+    workbook.close();
+
+    MockMultipartFile specificErrorFile = new MockMultipartFile(
+            "file",
+            "specific_error.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            out.toByteArray()
+    );
+
+    mockMvc.perform(multipart("/api/strategies/1/upload")
+                    .file(specificErrorFile)
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .with(csrf()))
+            .andExpect(status().isBadRequest()) // HTTP 400 예상
+            .andExpect(jsonPath("$.msg").value("EXCEL_UPLOAD_FAILED"))
+            .andExpect(jsonPath("$.error").value("Column 'average_loss' cannot be null"));
+
+    // Service 메서드 호출 검증
+    verify(excelUploadService, times(1)).extractAndSaveData(any(MockMultipartFile.class), eq(1L));
   }
 
   // CSRF 토큰이 누락된 경우 403 Forbidden을 반환하는지 확인하는 테스트

--- a/src/test/java/com/sysmatic2/finalbe/strategy/service/ExcelUploadServiceTest.java
+++ b/src/test/java/com/sysmatic2/finalbe/strategy/service/ExcelUploadServiceTest.java
@@ -2,12 +2,14 @@ package com.sysmatic2.finalbe.strategy.service;
 
 import com.sysmatic2.finalbe.exception.ExcelValidationException;
 import com.sysmatic2.finalbe.strategy.dto.DailyStatisticsReqDto;
+import com.sysmatic2.finalbe.strategy.entity.DailyStatisticsEntity;
 import com.sysmatic2.finalbe.strategy.entity.StrategyEntity;
 import com.sysmatic2.finalbe.strategy.repository.DailyStatisticsRepository;
 import com.sysmatic2.finalbe.strategy.repository.StrategyRepository;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
-import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +31,9 @@ public class ExcelUploadServiceTest {
   private StrategyRepository strategyRepository;
 
   @Mock
+  private DailyStatisticsService dailyStatisticsService;
+
+  @Mock
   private DailyStatisticsRepository dailyStatisticsRepository;
 
   @InjectMocks
@@ -40,7 +45,7 @@ public class ExcelUploadServiceTest {
   public void setup() {
     MockitoAnnotations.openMocks(this);
     validator = Validation.buildDefaultValidatorFactory().getValidator();
-    excelUploadService = new ExcelUploadService(validator, strategyRepository, dailyStatisticsRepository);
+    excelUploadService = new ExcelUploadService(validator, strategyRepository, dailyStatisticsService, dailyStatisticsRepository);
   }
 
   /**
@@ -71,34 +76,46 @@ public class ExcelUploadServiceTest {
             bos.toByteArray()
     );
 
-    // 전략 ID 설정 및 StrategyEntity 생성 (빌더 패턴 사용하지 않음)
+    // 전략 ID 설정 및 StrategyEntity 생성
     Long strategyId = 1L;
     StrategyEntity strategyEntity = new StrategyEntity();
     strategyEntity.setStrategyId(strategyId);
-    // 필요에 따라 다른 필드도 설정
-    // strategyEntity.setOtherField(...);
 
-    when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(strategyEntity));
-    when(dailyStatisticsRepository.saveAll(anyList())).thenReturn(List.of());
+    when(strategyRepository.existsById(eq(strategyId))).thenReturn(true);
+
+    // Mock the registerDailyStatistics method
+    doNothing().when(dailyStatisticsService).registerDailyStatistics(eq(strategyId), any(DailyStatisticsReqDto.class));
+
+    // Mock the repository to return the saved entity
+    DailyStatisticsEntity savedEntity = DailyStatisticsEntity.builder()
+            .dailyStatisticsId(1L)
+            .strategyEntity(strategyEntity)
+            .date(LocalDate.of(2024, 1, 1))
+            .depWdPrice(new BigDecimal("1000.00"))
+            .dailyProfitLoss(new BigDecimal("200.00"))
+            .build();
+
+    when(dailyStatisticsRepository.findByStrategyIdAndDate(eq(strategyId), eq(LocalDate.of(2024, 1, 1))))
+            .thenReturn(Optional.of(savedEntity));
 
     // 메서드 실행
-    List<DailyStatisticsReqDto> result = excelUploadService.extractAndSaveData(validFile, strategyId);
+    List<DailyStatisticsEntity> result = excelUploadService.extractAndSaveData(validFile, strategyId);
 
     // 검증
     assertNotNull(result);
     assertEquals(1, result.size());
 
-    DailyStatisticsReqDto dto = result.get(0);
-    assertEquals(LocalDate.of(2024, 1, 1), dto.getDate());
-
-    // BigDecimal 비교 수정
-    assertTrue(dto.getDepWdPrice().compareTo(new BigDecimal("1000.00")) == 0, "depWdPrice should be 1000.00");
-    assertTrue(dto.getDailyProfitLoss().compareTo(new BigDecimal("200.00")) == 0, "dailyProfitLoss should be 200.00");
+    DailyStatisticsEntity entity = result.get(0);
+    assertEquals(LocalDate.of(2024, 1, 1), entity.getDate());
+    assertTrue(entity.getDepWdPrice().compareTo(new BigDecimal("1000.00")) == 0, "depWdPrice should be 1000.00");
+    assertTrue(entity.getDailyProfitLoss().compareTo(new BigDecimal("200.00")) == 0, "dailyProfitLoss should be 200.00");
 
     // Repository 메서드 호출 검증
-    verify(strategyRepository, times(1)).findById(strategyId);
-    verify(dailyStatisticsRepository, times(1)).saveAll(anyList());
+    verify(strategyRepository, times(1)).existsById(eq(strategyId));
+    verify(dailyStatisticsService, times(1)).registerDailyStatistics(eq(strategyId), any(DailyStatisticsReqDto.class));
+    verify(dailyStatisticsRepository, times(1)).findByStrategyIdAndDate(eq(strategyId), eq(LocalDate.of(2024, 1, 1)));
   }
+
 
   /**
    * extractAndSaveData 메서드가 유효하지 않은 전략 ID일 경우 예외를 던지는지 테스트
@@ -131,18 +148,19 @@ public class ExcelUploadServiceTest {
     // 유효하지 않은 전략 ID 설정
     Long invalidStrategyId = 999L;
 
-    when(strategyRepository.findById(invalidStrategyId)).thenReturn(Optional.empty());
+    when(strategyRepository.existsById(invalidStrategyId)).thenReturn(false);
 
     // 메서드 실행 및 예외 검증
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
       excelUploadService.extractAndSaveData(validFile, invalidStrategyId);
     });
 
-    assertEquals("Invalid strategyId: " + invalidStrategyId, exception.getMessage());
+    assertEquals("유효하지 않은 전략 ID입니다: " + invalidStrategyId, exception.getMessage());
 
-    // Repository 메서드 호출 검증: findById가 호출되었는지 확인
-    verify(strategyRepository, times(1)).findById(invalidStrategyId);
-    verify(dailyStatisticsRepository, times(0)).saveAll(anyList());
+    // Repository 메서드 호출 검증: existsById만 호출되었는지 확인
+    verify(strategyRepository, times(1)).existsById(invalidStrategyId);
+    verify(dailyStatisticsService, times(0)).registerDailyStatistics(anyLong(), any(DailyStatisticsReqDto.class));
+    verify(dailyStatisticsRepository, times(0)).findByStrategyIdAndDate(anyLong(), any(LocalDate.class));
   }
 
   /**
@@ -173,15 +191,15 @@ public class ExcelUploadServiceTest {
             bos.toByteArray()
     );
 
-    // 전략 ID 설정 및 StrategyEntity 생성 (빌더 패턴 사용하지 않음)
+    // 전략 ID 설정 및 StrategyEntity 생성
     Long strategyId = 1L;
-    StrategyEntity strategyEntity = new StrategyEntity();
-    strategyEntity.setStrategyId(strategyId);
-    // 필요에 따라 다른 필드도 설정
-    // strategyEntity.setOtherField(...);
 
-    when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(strategyEntity));
-    when(dailyStatisticsRepository.saveAll(anyList())).thenThrow(new RuntimeException("Database error"));
+    // Mocking repository and service behavior
+    when(strategyRepository.existsById(eq(strategyId))).thenReturn(true);
+
+    // Mocking the service method to throw an exception
+    doThrow(new RuntimeException("Database error"))
+            .when(dailyStatisticsService).registerDailyStatistics(eq(strategyId), any(DailyStatisticsReqDto.class));
 
     // 메서드 실행 및 예외 검증
     RuntimeException exception = assertThrows(RuntimeException.class, () -> {
@@ -190,9 +208,10 @@ public class ExcelUploadServiceTest {
 
     assertEquals("Database error", exception.getMessage());
 
-    // Repository 메서드 호출 검증
-    verify(strategyRepository, times(1)).findById(strategyId);
-    verify(dailyStatisticsRepository, times(1)).saveAll(anyList());
+    // Repository 및 서비스 호출 검증
+    verify(strategyRepository, times(1)).existsById(eq(strategyId));
+    verify(dailyStatisticsService, times(1)).registerDailyStatistics(eq(strategyId), any(DailyStatisticsReqDto.class));
+    verify(dailyStatisticsRepository, times(0)).findByStrategyIdAndDate(anyLong(), any(LocalDate.class));
   }
 
   /**
@@ -221,7 +240,11 @@ public class ExcelUploadServiceTest {
     // 필요에 따라 다른 필드도 설정
     // strategyEntity.setOtherField(...);
 
-    when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(strategyEntity));
+    when(strategyRepository.existsById(strategyId)).thenReturn(true);
+
+    // Mocking the repository to throw exception when multiple sheets are present
+    // Since the service itself checks for multiple sheets and throws exception,
+    // we don't need to mock repository behavior here.
 
     // 메서드 실행 및 예외 검증
     ExcelValidationException exception = assertThrows(ExcelValidationException.class, () -> {
@@ -230,8 +253,9 @@ public class ExcelUploadServiceTest {
 
     assertEquals("엑셀 파일에 여러 시트가 포함되어 있습니다. 첫 번째 시트만 허용됩니다.", exception.getMessage());
 
-    // Repository 메서드 호출 검증: 예외 발생 시 findById는 호출되지 않았어야 함
-    verify(strategyRepository, never()).findById(anyLong());
-    verify(dailyStatisticsRepository, times(0)).saveAll(anyList());
+    // Repository 메서드 호출 검증
+    verify(strategyRepository, times(1)).existsById(strategyId);
+    verify(dailyStatisticsService, times(0)).registerDailyStatistics(anyLong(), any(DailyStatisticsReqDto.class));
+    verify(dailyStatisticsRepository, times(0)).findByStrategyIdAndDate(anyLong(), any(LocalDate.class));
   }
 }


### PR DESCRIPTION
**바로 머지하지 마세요! 검토 후 머지해야합니다!**

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
엑셀 파일 업로드 API 수정 및 테스트 코드 추가 구현
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. `extractAndSaveData` 메서드에서 `findByStrategyIdAndDate` 메서드 활용하여 데이터 저장 로직 개선
2. `ExcelUploadServiceTest`에서 Mockito의 `ArgumentMatchers.eq`를 사용하여 매개변수 매칭 오류 해결
3. 잘못된 엑셀 파일 형식 및 유효하지 않은 전략 ID 처리 로직 수정 및 관련 예외 메시지 변경
4. `ExcelUploadController` 응답 메시지 및 상태 코드 검증을 위한 테스트 케이스 추가
5. 엑셀 파일 데이터 중복 확인 및 예외 처리 로직 추가

<br />

## :: 쓰이는 모듈


<br />

## :: 기타 질문 및 특이 사항

