### PR TITLE
fix: coefficient_of_variation 컬럼의 precision 및 scale 수정

### DIFF
--- a/src/main/java/com/sysmatic2/finalbe/strategy/entity/DailyStatisticsEntity.java
+++ b/src/main/java/com/sysmatic2/finalbe/strategy/entity/DailyStatisticsEntity.java
@@ -158,7 +158,7 @@ public class DailyStatisticsEntity extends Auditable {
     @Column(name = "average_profit_loss_ratio", nullable = false, precision = 10, scale = 4)
     private BigDecimal averageProfitLossRatio; // 평균손익비 - 평균이익 / 평균손실(절대값)
 
-    @Column(name = "coefficient_of_variation", nullable = false, precision = 10, scale = 4)
+    @Column(name = "coefficient_of_variation", nullable = false, precision = 15, scale = 6)
     private BigDecimal coefficientOfVariation; // 변동계수 - 기준일까지의 일손익 표준편차 / 기준일 평균손익 * 100
 
     @Column(name = "sharp_ratio", nullable = false, precision = 10, scale = 4)


### PR DESCRIPTION
- 데이터 손실 및 저장 오류 방지를 위해 precision을 15로, scale을 6으로 조정.

**바로 머지하지 마세요! 검토 후 머지해야합니다!**

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
 coefficient_of_variation 컬럼의 precision 및 scale 수정



<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 데이터 손실 및 저장 오류 방지를 위해 precision을 15로, scale을 6으로 조정.

<br />

## :: 쓰이는 모듈


<br />

## :: 기타 질문 및 특이 사항
