### PR TITLE
상담 api 프로필 사진 url 추가

### DIFF
--- a/src/main/java/com/sysmatic2/finalbe/cs/dto/ConsultationCreateDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/cs/dto/ConsultationCreateDto.java
@@ -48,5 +48,6 @@ public class ConsultationCreateDto {
   private String content;
 
   @NotNull(message = "상담 상태는 필수입니다.")
-  private ConsultationStatus status;
+  @Builder.Default
+  private ConsultationStatus status = ConsultationStatus.PENDING; // 기본값 설정
 }

--- a/src/main/java/com/sysmatic2/finalbe/cs/dto/ConsultationDetailResponseDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/cs/dto/ConsultationDetailResponseDto.java
@@ -1,46 +1,46 @@
-package com.sysmatic2.finalbe.cs.dto;
+  package com.sysmatic2.finalbe.cs.dto;
 
-import com.sysmatic2.finalbe.cs.entity.ConsultationStatus;
-import java.math.BigDecimal;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+  import com.sysmatic2.finalbe.cs.entity.ConsultationStatus;
+  import java.math.BigDecimal;
+  import lombok.AllArgsConstructor;
+  import lombok.Builder;
+  import lombok.Data;
+  import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+  import java.time.LocalDateTime;
 
-/**
- * 상담 상세 응답 DTO
- */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class ConsultationDetailResponseDto {
-  private Long id;
-  private String investorId;
-  private String investorName;
-  private String investorProfileUrl; // 추가
-  private String traderId;
-  private String traderName;
-  private String traderProfileUrl; // 추가
+  /**
+   * 상담 상세 응답 DTO
+   */
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public class ConsultationDetailResponseDto {
+    private Long id;
+    private String investorId;
+    private String investorName;
+    private String investorProfileUrl; // 추가
+    private String traderId;
+    private String traderName;
+    private String traderProfileUrl; // 추가
 
-  private Long strategyId; // 전략 ID 포함
-  private String strategyName; // 전략 이름 포함
+    private Long strategyId; // 전략 ID 포함
+    private String strategyName; // 전략 이름 포함
 
-  private BigDecimal investmentAmount;
-  private LocalDateTime investmentDate;
-  private String title;
-  private String content;
-  private ConsultationStatus status;
-  private LocalDateTime createdAt;
-  private LocalDateTime updatedAt;
+    private BigDecimal investmentAmount;
+    private LocalDateTime investmentDate;
+    private String title;
+    private String content;
+    private ConsultationStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
-  // 추가된 필드: 트레이더의 답변 내용 및 답변 날짜
-  private String replyContent;
-  private LocalDateTime answerDate;
+    // 추가된 필드: 트레이더의 답변 내용 및 답변 날짜
+    private String replyContent;
+    private LocalDateTime answerDate;
 
-  // 추가된 필드: 답변 생성일 및 수정일
-  private LocalDateTime replyCreatedAt;
-  private LocalDateTime replyUpdatedAt;
-}
+    // 추가된 필드: 답변 생성일 및 수정일
+    private LocalDateTime replyCreatedAt;
+    private LocalDateTime replyUpdatedAt;
+  }

--- a/src/main/java/com/sysmatic2/finalbe/cs/mapper/ConsultationMapper.java
+++ b/src/main/java/com/sysmatic2/finalbe/cs/mapper/ConsultationMapper.java
@@ -44,12 +44,12 @@ public class ConsultationMapper {
   public ConsultationDetailResponseDto toDetailResponseDto(ConsultationEntity entity) {
     return ConsultationDetailResponseDto.builder()
             .id(entity.getId())
-            .investorId(entity.getInvestor().getMemberId())
-            .investorName(entity.getInvestor().getNickname())
-            .traderId(entity.getTrader().getMemberId())
-            .traderName(entity.getTrader().getNickname())
-            .strategyId(entity.getStrategy().getStrategyId())
-            .strategyName(entity.getStrategy().getStrategyTitle())
+            .investorId(entity.getInvestor() == null ? null : entity.getInvestor().getMemberId())
+            .investorName(entity.getInvestor() == null ? "탈퇴한 사용자" : entity.getInvestor().getNickname())
+            .traderId(entity.getTrader() == null ? null : entity.getTrader().getMemberId())
+            .traderName(entity.getTrader() == null ? "탈퇴한 사용자" : entity.getTrader().getNickname())
+            .strategyId(entity.getStrategy() == null ? null : entity.getStrategy().getStrategyId())
+            .strategyName(entity.getStrategy() == null ? "전략 정보 없음" : entity.getStrategy().getStrategyTitle())
             .investmentAmount(entity.getInvestmentAmount())
             .investmentDate(entity.getInvestmentDate())
             .title(entity.getTitle())
@@ -61,6 +61,8 @@ public class ConsultationMapper {
             .answerDate(entity.getAnswerDate())
             .replyCreatedAt(entity.getReplyCreatedAt())
             .replyUpdatedAt(entity.getReplyUpdatedAt())
+            .investorProfileUrl(entity.getInvestor() == null ? null : entity.getInvestor().getProfilePath())
+            .traderProfileUrl(entity.getTrader() == null ? null : entity.getTrader().getProfilePath())
             .build();
   }
 
@@ -70,13 +72,15 @@ public class ConsultationMapper {
   public ConsultationListResponseDto toListResponseDto(ConsultationEntity entity) {
     return ConsultationListResponseDto.builder()
             .id(entity.getId())
-            .investorName(entity.getInvestor().getNickname())
-            .traderName(entity.getTrader().getNickname())
-            .strategyName(entity.getStrategy().getStrategyTitle())
+            .investorName(entity.getInvestor() == null ? "탈퇴한 사용자" : entity.getInvestor().getNickname())
+            .traderName(entity.getTrader() == null ? "탈퇴한 사용자" : entity.getTrader().getNickname())
+            .strategyName(entity.getStrategy() == null ? "전략 정보 없음" : entity.getStrategy().getStrategyTitle())
             .investmentDate(entity.getInvestmentDate())
             .title(entity.getTitle())
             .status(entity.getStatus())
             .createdAt(entity.getCreatedAt())
+            .investorProfileUrl(entity.getInvestor() == null ? null : entity.getInvestor().getProfilePath())
+            .traderProfileUrl(entity.getTrader() == null ? null : entity.getTrader().getProfilePath())
             .build();
   }
 


### PR DESCRIPTION
**바로 머지하지 마세요! 검토 후 머지해야합니다!**

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 상담 응답에 프로필 URL 포함되도록 매퍼 수정
- 상담 생성 시 기본 상태를 Pending으로 설정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. **상담 응답에 프로필 URL 포함되도록 매퍼 수정**
   - 투자자 및 트레이더의 프로필 URL이 `ConsultationListResponseDto`와 `ConsultationDetailResponseDto`에 포함되도록 수정.
   - `MemberEntity`의 `profilePath`를 이용해 URL을 매핑.

2. **상담 생성 시 기본 상태를 Pending으로 설정**
   - `ConsultationCreateDto`를 처리하는 로직에서 기본 상태를 `Pending`으로 설정.
   - `ConsultationStatus` 값 검증 로직 추가.

<br />

## :: 쓰이는 모듈
- 사용 모듈에 변경사항 없음.

<br />

## :: 기타 질문 및 특이 사항
- 백엔드 배포 환경에서 `nginx` 관련 설정 검토 필요.
- 프로필 이미지 URL이 없는 경우 기본 이미지를 반환하는 로직 추가 고려.
