### PR TITLE
Feat : 관심전략 기능 추가

### DIFF
--- a/src/main/java/com/sysmatic2/finalbe/exception/DuplicateFollowingStrategyException.java
+++ b/src/main/java/com/sysmatic2/finalbe/exception/DuplicateFollowingStrategyException.java
@@ -1,0 +1,6 @@
+package com.sysmatic2.finalbe.exception;
+
+public class DuplicateFollowingStrategyException extends RuntimeException{
+    public DuplicateFollowingStrategyException(String message) { super(message);
+    }
+}

--- a/src/main/java/com/sysmatic2/finalbe/member/controller/FollowingStrategyController.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/controller/FollowingStrategyController.java
@@ -1,0 +1,90 @@
+package com.sysmatic2.finalbe.member.controller;
+
+import com.sysmatic2.finalbe.member.dto.*;
+import com.sysmatic2.finalbe.member.entity.FollowingStrategyEntity;
+import com.sysmatic2.finalbe.member.entity.FollowingStrategyFolderEntity;
+import com.sysmatic2.finalbe.member.repository.MemberRepository;
+import com.sysmatic2.finalbe.member.service.FollowingStrategyService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+
+public class FollowingStrategyController {
+    private final FollowingStrategyService followingStrategyService;
+    private final MemberRepository memberRepository;
+
+    //관심 전략 등록
+    @PostMapping("/following-strategy")
+    public ResponseEntity<Map<String,Object>> createFollwingStrategy(@RequestBody FollowingStrategyRequestDto followingStrategyDto,
+                                                                     @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        FollowingStrategyResponseDto responseDto = followingStrategyService.createFollowingStrategy(followingStrategyDto,customUserDetails);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                "message","관심전략이 정상적으로 등록되었습니다.",
+                "data",responseDto
+        ));
+    }
+
+    //관심 전략 목록 조회
+    @GetMapping("/follwing-strategy/list/{folderId}")
+    public ResponseEntity<Map<String,Object>> getListFollowingStrategy(@PathVariable Long folderId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        //ArrayList<FollowingStrategyListDto> list = followingStrategyService.getListFollowingStrategy(followingStrategyRequestDto, customUserDetails);
+
+        List<FollowingStrategyListDto> list = followingStrategyService.getListFollowingStrategy1(folderId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of(
+                "message","관심전략 목록이 정상적으로 조회되었습니다.",
+                "data", list
+        ));
+    }
+    //관심 전략 목록 조회(페이징처리)
+    @GetMapping("/follwing-strategy/page/{folderId}")
+    public ResponseEntity<Map<String,Object>> getListFollowingStrategyPage(@PathVariable Long folderId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails, Pageable pageable){
+
+        Page<FollowingStrategyListDto> page  = followingStrategyService.getListFollowingStrategyPage(pageable,10,folderId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of(
+                "message","관심전략 목록이 정상적으로 조회되었습니다.",
+                "data", page.getContent(),       // 페이징된 데이터
+                "currentPage", page.getNumber(), // 현재 페이지
+                "totalItems", page.getTotalElements(), // 전체 데이터 수
+                "totalPages", page.getTotalPages() // 전체 페이지 수
+        ));
+    }
+
+
+    //관심 전략 삭제
+    @DeleteMapping("/follwing-strategy/{followingStrategyId}")
+    public ResponseEntity<Map<String,String>> deleteFollowingStrategy(@PathVariable Long followingStrategyId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        followingStrategyService.deleteFollowingStrategy(followingStrategyRequestDto,customUserDetails);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of(
+                "message","관심전략이 정상적으로 삭제되었습니다."
+        ));
+    }
+
+    //관심 전략 이동
+
+    //관심전략폴더ID별 관심 전략 갯수 count
+    @GetMapping("/follwing-strategy/{folderId}")
+    public ResponseEntity<Map<String,Object>> getCountFollowingStrategy(@PathVariable Long folderId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        int count = followingStrategyService.countFollowingStrategy(folderId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                "message","정상적으로 조회 성공했습니다.",
+                "count",count
+        ));
+    }
+
+}

--- a/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyListDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyListDto.java
@@ -1,0 +1,37 @@
+package com.sysmatic2.finalbe.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FollowingStrategyListDto {
+    private Long followingStrategyId;
+    private Long strategyId;
+    private BigDecimal kp_ratio;
+    //SM-Score
+    private BigDecimal smScore;
+    private String strategyTitle;
+
+    //팔로워수
+    private Long followersCount;
+
+    //순위
+    //분석그래프
+    //수익률
+    //MDD
+
+    public FollowingStrategyListDto(Long followingStrategyId, Long strategyId, Long followersCount, BigDecimal kp_ratio, BigDecimal smScore, String strategyTitle) {
+        this.followingStrategyId = followingStrategyId;
+        this.strategyId = strategyId;
+        this.followersCount = followersCount;
+        this.kp_ratio = kp_ratio;
+        this.smScore = smScore;
+        this.strategyTitle = strategyTitle;
+    }
+}

--- a/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyRequestDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyRequestDto.java
@@ -1,0 +1,12 @@
+package com.sysmatic2.finalbe.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FollowingStrategyRequestDto {
+    private Long folderId;
+    private Long strategyId;
+    private Long followingStrategyId;
+}

--- a/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyResponseDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyResponseDto.java
@@ -1,0 +1,15 @@
+package com.sysmatic2.finalbe.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FollowingStrategyResponseDto {
+    private Long folderId;
+    private Long strategyId;
+    private Long followingStrategyId;
+    private String strategyName;
+}

--- a/src/main/java/com/sysmatic2/finalbe/member/entity/FollowingStrategyEntity.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/entity/FollowingStrategyEntity.java
@@ -4,6 +4,7 @@ import com.sysmatic2.finalbe.common.Auditable;
 import com.sysmatic2.finalbe.strategy.entity.StrategyEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @ToString
+@NoArgsConstructor
 public class FollowingStrategyEntity extends Auditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,4 +36,12 @@ public class FollowingStrategyEntity extends Auditable {
 
     @Column(name = "followed_at", nullable = false)
     private LocalDateTime followedAt;
+
+    public FollowingStrategyEntity(FollowingStrategyFolderEntity followingStrategyFolder, MemberEntity member, StrategyEntity strategy, LocalDateTime followedAt) {
+
+        this.followingStrategyFolder = followingStrategyFolder;
+        this.member = member;
+        this.strategy = strategy;
+        this.followedAt = followedAt;
+    }
 }

--- a/src/main/java/com/sysmatic2/finalbe/member/repository/FollowingStrategyRepository.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/repository/FollowingStrategyRepository.java
@@ -1,9 +1,51 @@
 package com.sysmatic2.finalbe.member.repository;
 
+import com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto;
 import com.sysmatic2.finalbe.member.entity.FollowingStrategyEntity;
+import com.sysmatic2.finalbe.member.entity.FollowingStrategyFolderEntity;
 import com.sysmatic2.finalbe.strategy.entity.StrategyEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface FollowingStrategyRepository extends JpaRepository<FollowingStrategyEntity, Long> {
     void deleteAllByStrategy(StrategyEntity strategy);
+    FollowingStrategyEntity findByFollowingStrategyFolderAndStrategy(FollowingStrategyFolderEntity followingStrategyFolder, StrategyEntity strategy);
+    int deleteByFollowingStrategyId(Long followingStrategyId);
+    boolean existsByFollowingStrategyId(Long followingStrategyId);
+
+    int countByFollowingStrategyFolder(FollowingStrategyFolderEntity followingStrategyFolder);
+
+    //Page<FollowingStrategyListDto> findAllAsFollowingStrategyListDto(Pageable pageable);
+
+    //Page<FollowingStrategyEntity> findByStats(String stats, Pageable pageable);
+
+    //관심전략폴더ID에 등록된 전략ID의 리스트 정보를 조회
+
+//        @Query("SELECT new com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto("
+//                +"f.followingStrategyId, s.followers_count, s.kp_ratio, s.smScore, s.StrategyTitle) " +
+//                "FROM FollowingStrategyEntity f, StrategyEntity s"+
+//                "WHERE f.StrategyEntity = s.StrategyEntity"+
+//                "AND f.followingStrategyFolder =:follwingStrategyFolder")
+
+    @Query("SELECT new com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto(" +
+            "f.followingStrategyId, s.strategyId, s.followersCount, s.kpRatio, s.smScore, s.strategyTitle) " +
+            "FROM FollowingStrategyEntity f " +
+            "JOIN f.strategy s " +
+            "WHERE f.followingStrategyFolder = :followingStrategyFolder AND s.isPosted = 'y' " +
+            "AND s.isApproved = 'y'")
+    List<FollowingStrategyListDto> getListFollowingStrategy1(@Param("followingStrategyFolder") FollowingStrategyFolderEntity followingStrategyFolder);
+
+    @Query("SELECT new com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto(" +
+            "f.followingStrategyId, s.strategyId, s.followersCount, s.kpRatio, s.smScore, s.strategyTitle) " +
+            "FROM FollowingStrategyEntity f " +
+            "JOIN f.strategy s " +
+            "WHERE f.followingStrategyFolder = :followingStrategyFolder AND s.isPosted = 'y' " +
+            "AND s.isApproved = 'y'")
+    Page<FollowingStrategyListDto> getListFollowingStrategyPage(@Param("followingStrategyFolder") FollowingStrategyFolderEntity followingStrategyFolder, Pageable pageable);
+
 }

--- a/src/main/java/com/sysmatic2/finalbe/member/service/FollowingStrategyService.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/service/FollowingStrategyService.java
@@ -1,0 +1,133 @@
+package com.sysmatic2.finalbe.member.service;
+
+import com.sysmatic2.finalbe.exception.DuplicateFollowingStrategyException;
+import com.sysmatic2.finalbe.member.dto.CustomUserDetails;
+import com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto;
+import com.sysmatic2.finalbe.member.dto.FollowingStrategyRequestDto;
+import com.sysmatic2.finalbe.member.dto.FollowingStrategyResponseDto;
+import com.sysmatic2.finalbe.member.entity.FollowingStrategyEntity;
+import com.sysmatic2.finalbe.member.entity.FollowingStrategyFolderEntity;
+import com.sysmatic2.finalbe.member.entity.MemberEntity;
+import com.sysmatic2.finalbe.member.repository.FollowingStrategyFolderRepository;
+import com.sysmatic2.finalbe.member.repository.FollowingStrategyRepository;
+import com.sysmatic2.finalbe.strategy.entity.StrategyEntity;
+import com.sysmatic2.finalbe.strategy.repository.StrategyRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class FollowingStrategyService {
+    private final FollowingStrategyRepository followingStrategyRepository;
+    private final StrategyRepository strategyRepository;
+    private final FollowingStrategyFolderRepository followingStrategyFolderRepository;
+
+    //폴더별 관심전략 목록 조회 서비스
+    public List<FollowingStrategyListDto> getListFollowingStrategy1(Long folderId){
+//        FollowingStrategyListDto listDto = new FollowingStrategyListDto();
+//        listDto.setStrategyName();//전략이름
+//        listDto.setFollowers_count();
+//        listDto.setSmScore();
+//        listDto.setFollowingStrategyId();
+//        listDto.setStrategyId();
+
+       // ArrayList<FollowingStrategyListDto> list = new ArrayList<>();
+        //폴더엔티티를 던져줘야해?
+        FollowingStrategyFolderEntity folderEntity = followingStrategyFolderRepository.findById(folderId).get();
+        List<FollowingStrategyListDto> list = followingStrategyRepository.getListFollowingStrategy1(folderEntity);
+
+        return list;
+    }
+
+    //폴더별 관심전략 목록 조회 페이징
+    public Page<FollowingStrategyListDto> getListFollowingStrategyPage(Pageable pageable,int size,Long folderId){
+        //Pageable pageable = PageRequest.of(page, size);
+        FollowingStrategyFolderEntity folderEntity = followingStrategyFolderRepository.findById(folderId).get();
+        return followingStrategyRepository.getListFollowingStrategyPage(folderEntity,pageable);
+    }
+
+//    public Page<FollowingStrategyEntity> getEntitesByStatus(String status,int page,int size){
+//        Pageable pageable = PageRequest.of(page, size);
+//        return followingStrategyRepository.findByStats(status,pageable);
+//    }
+
+    //폴더ID 별 등록된 관심전략 폴더 Count 조회
+    public int countFollowingStrategy(long folderId) {
+        FollowingStrategyFolderEntity folderEntity = followingStrategyFolderRepository.findById(folderId).get();
+        return followingStrategyRepository.countByFollowingStrategyFolder(folderEntity);
+    }
+
+    //관심 전략 등록 서비스
+    @Transactional
+    public FollowingStrategyResponseDto createFollowingStrategy(FollowingStrategyRequestDto requestDto, CustomUserDetails customUserDetails){
+        FollowingStrategyResponseDto ResponseDto = new FollowingStrategyResponseDto();
+        StrategyEntity strategyEntity = strategyRepository.findById(requestDto.getStrategyId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 전략이 존재하지 않습니다."));
+        FollowingStrategyFolderEntity followingStrategyFolderEntity = followingStrategyFolderRepository.findById(requestDto.getFolderId())
+                .orElseThrow(()-> new IllegalArgumentException("해당 ID의 폴더가 존재하지 않습니다."));
+        //이미 등록된 관심전략 체크하는 로직 추가 필요
+        //선택한 종목이 해당 관심 전략에 이미 등록되어 있습니다.
+        //폴더에 해당 전략id가 있는지 체크
+        FollowingStrategyEntity folllowingStrategeyEntity = followingStrategyRepository.findByFollowingStrategyFolderAndStrategy(followingStrategyFolderEntity,strategyEntity);
+
+        if(folllowingStrategeyEntity != null){
+               throw new DuplicateFollowingStrategyException("선택한 종목이 해당 관심 전략폴더에 이미 등록되어 있습니다.");
+        }
+
+       MemberEntity member = customUserDetails.getMemberEntity();
+        if (member == null) {
+            throw new IllegalStateException("회원 정보가 없습니다.");
+        }
+
+        LocalDateTime followedAt = LocalDateTime.now();
+
+        FollowingStrategyEntity followingStrategyEntity = new FollowingStrategyEntity(
+                followingStrategyFolderEntity,member,strategyEntity,followedAt);
+        followingStrategyRepository.save(followingStrategyEntity);
+
+        //관심전략 등록하면 전략의 follower_count 수 증가해줘야함
+        strategyEntity.incrementFollowersCount();
+        strategyRepository.save(strategyEntity);
+
+        ResponseDto.setFolderId(requestDto.getFolderId());
+        ResponseDto.setStrategyId(requestDto.getStrategyId());
+        ResponseDto.setFollowingStrategyId(followingStrategyEntity.getFollowingStrategyId());
+        ResponseDto.setStrategyName(strategyEntity.getStrategyTitle());
+
+        return ResponseDto;
+    }
+
+    //관심 전략 삭제
+    @Transactional
+    public void deleteFollowingStrategy(FollowingStrategyRequestDto requestDto, CustomUserDetails customUserDetails){
+        //삭제할 관심전략 조회
+        Optional<FollowingStrategyEntity> followingStrategyEntityOptional = followingStrategyRepository.findById(requestDto.getFollowingStrategyId());
+
+        if(followingStrategyEntityOptional.isEmpty()){
+            throw new IllegalStateException("삭제할 관심전략이 존재하지 않습니다. 관심전략ID:" + requestDto.getFollowingStrategyId());
+        }
+        FollowingStrategyEntity followingStrategyEntity = followingStrategyEntityOptional.get();
+        StrategyEntity strategyEntity = followingStrategyEntity.getStrategy();
+        if(!followingStrategyEntity.getCreatedBy().equals(customUserDetails.getMemberId())){
+            throw new IllegalStateException("해당 관심전략을 삭제 권한이 없습니다. 관심전략ID:" + requestDto.getFollowingStrategyId());
+        }
+
+        int resultCnt = followingStrategyRepository.deleteByFollowingStrategyId(requestDto.getFollowingStrategyId());
+
+        if(resultCnt == 0){
+            throw new IllegalStateException("삭제할 전략 ID가 존재하지 않습니다. 관심전략ID:" + requestDto.getFollowingStrategyId());
+        }
+
+        //관심전략 삭제하면 전략의 follower_count 수 감소시켜줘야함
+        strategyEntity.decrementFollowersCount();
+        strategyRepository.save(strategyEntity);
+    }
+
+}

--- a/src/main/java/com/sysmatic2/finalbe/strategy/entity/StrategyEntity.java
+++ b/src/main/java/com/sysmatic2/finalbe/strategy/entity/StrategyEntity.java
@@ -90,4 +90,15 @@ public class StrategyEntity extends Auditable {
     //전략(1) : 관계(N)
     @OneToMany(mappedBy = "strategyEntity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StrategyIACEntity> strategyIACEntities;
+
+    public void incrementFollowersCount() {
+        this.followersCount++;
+    }
+
+    // 팔로우 감소 (followersCount가 음수가 되지 않도록 보호)
+    public void decrementFollowersCount() {
+        if (this.followersCount > 0) {
+            this.followersCount--;
+        }
+    }
 }


### PR DESCRIPTION
**바로 머지하지 마세요! 검토 후 머지해야합니다!**

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
Feat : 관심전략 기능 추가
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1.FollowingStrategyRepository 
-관심전략 목록조회(페이징)
-관심전략 삭제(관심전략ID)
-관심전략 count조회(폴더별)
-관심전략 등록 확인

2.FollowingStrategyEntity
-생성자 추가

3.FollowingStrategyService
-관심전략 등록
-관심전략 목록 조회
-관심전략 목록 조회(페이징)
-관심전략 삭제
-관심전략 폴더ID별 관심전략 갯수 Count

4.FollowingStrategyController
-관심전략 등록
-관심전략 목록 조회
-관심전략 목록 조회(페이징)
-관심전략 삭제
-관심전략 폴더ID별 관심전략 갯수 Count

5..관심전략에서 사용할 Dto 추가
-FollowingStrategyRequestDto
-FollowingStrategyResponseDto
-FollowingStrategyListDto

6.관심전략 예외처리
-DuplicateFollowingStrategyException
<br />

## :: 쓰이는 모듈
<br />

## :: 기타 질문 및 특이 사항

