### PR TITLE
문의 api 정렬 수정

### DIFF
--- a/src/main/java/com/sysmatic2/finalbe/cs/service/ConsultationService.java
+++ b/src/main/java/com/sysmatic2/finalbe/cs/service/ConsultationService.java
@@ -18,6 +18,7 @@ import com.sysmatic2.finalbe.strategy.repository.StrategyRepository;
 import java.math.BigDecimal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,6 +91,9 @@ public class ConsultationService {
   @Transactional(readOnly = true)
   public PaginatedResponseDto<ConsultationListResponseDto> getConsultations(String investorId, String traderId, int page) {
     Page<ConsultationEntity> consultationsPage;
+
+    // PageRequest에 정렬 기준 추가 (createdAt 필드를 기준으로 내림차순 정렬)
+    PageRequest pageRequest = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
 
     if (investorId != null && !investorId.isEmpty()) {
       consultationsPage = consultationRepository.findAllByInvestor_MemberId(investorId, PageRequest.of(page, 10));


### PR DESCRIPTION
**바로 머지하지 마세요! 검토 후 머지해야합니다!**

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
상담 목록을 최신 날짜 순으로 정렬하도록 기능 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. `ConsultationService`의 `getConsultations` 메서드를 수정하여 상담 목록이 `createdAt` 필드를 기준으로 내림차순 정렬되도록 변경
2. `PageRequest`에 `Sort.by(Sort.Direction.DESC, "createdAt")`을 추가하여 최신 상담이 먼저 조회되도록 구현
3. 모든 관련 로직에 정렬 기준 적용 완료

<br />

## :: 쓰이는 모듈
- Spring Data JPA: 정렬을 위한 `Sort` 클래스 사용

<br />

## :: 기타 질문 및 특이 사항
- 정렬 기준이 되는 `createdAt` 필드 외에 추가로 정렬 기준을 변경해야 할 가능성이 있는지 검토 부탁드립니다.
- 기존 클라이언트에서 정렬 방식 변경에 따른 영향이 없는지 확인이 필요합니다.
